### PR TITLE
Enhancement: Support identification of more than one duplicate photo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It is fairly common, for instance, to copy image files from your Camera Roll, an
 
 - The default duplicate criteria is to match only by `Date Taken` (e.g. `2021-01-01T00:11:22+0000`).
     - Choose whether the duplicate criteria should also include file size and file hash.
-- Searches two groups of folders (i.e. source and other) for image files with `Date Taken` attribute.
+- Searches two groups of folders (i.e. source and other) for all descendent image files with an existing `Date Taken` attribute.
 - Compares files of the two groups of folders, identifying duplicates using the criteria you defined
 - Finally, exports duplicates into a `duplicates.json` file.
 


### PR DESCRIPTION
Previously only at most one duplicate photo could be identified because the hashtable overrode its keys, such that existing entries were overridden. This made it such that only one duplicate file could ever be identified.

Now, the value of the entry is an array of duplicate files.

Also improves logging.